### PR TITLE
Add function to send custom fingerprint with error message

### DIFF
--- a/rollbar.cabal
+++ b/rollbar.cabal
@@ -1,5 +1,5 @@
 name:                rollbar
-version:             1.1.0
+version:             1.1.1
 synopsis:            error tracking through rollbar.com
 -- description:
 homepage:            https://github.com/azara/rollbar-haskell


### PR DESCRIPTION
Rollbar API allows sending a fingerprint in JSON object to use in grouping errors (https://rollbar.com/docs/grouping-algorithm/). This change adds a function to enable sending such a fingerprint.